### PR TITLE
Update io.py to let tier_files ignore hidden files start with a dot "."

### DIFF
--- a/label_studio/utils/io.py
+++ b/label_studio/utils/io.py
@@ -100,7 +100,7 @@ def remove_file_or_dir(path):
 def iter_files(root_dir, ext):
     for root, _, files in os.walk(root_dir):
         for f in files:
-            if f.lower().endswith(ext):
+            if f.lower().endswith(ext) and not f.lower().startswith('.'):
                 yield os.path.join(root, f)
 
 


### PR DESCRIPTION
When we are checking the task completion json files many text editor used will often created a hidden file such as "._2.json" under the path `PROJECT/completions`.
This will cause problem when label-studio is iterating though the json files, and through an error like this:
```
Project loading error
invalid literal for int() with base 10: '._2'
Traceback
Traceback (most recent call last):
  File "/apps/conda/tom/envs/label-studio/lib/python3.8/site-packages/label_studio/utils/misc.py", line 89, in exception_f
    return f(*args, **kwargs)
  File "/apps/conda/tom/envs/label-studio/lib/python3.8/site-packages/label_studio/server.py", line 224, in tasks_page
    serialized_project = project.serialize()
  File "/apps/conda/tom/envs/label-studio/lib/python3.8/site-packages/label_studio/project.py", line 889, in serialize
    'completion_count': len(project.get_completions_ids()),
  File "/apps/conda/tom/envs/label-studio/lib/python3.8/site-packages/label_studio/project.py", line 458, in get_completions_ids
    completion_ids = set(self.target_storage.ids())
  File "/apps/conda/tom/envs/label-studio/lib/python3.8/site-packages/label_studio/storage/filesystem.py", line 112, in ids
    yield int(os.path.splitext(os.path.basename(f))[0])
ValueError: invalid literal for int() with base 10: '._2'
```

To solve this problem the io.py tier_files function has been modified so those hidden files are ignored.